### PR TITLE
add working-directory input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+# 1.1.0
+
+- Add support for overriding the working directory

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ You can also specify a `tag` input to register the published package with, such 
         with:
           tag: beta
 ```
+
+If the package.json is not in the current directory, you can override the working directory:
+
+```
+    steps:
+      - uses: babbel/publish-npm
+        with:
+          working-directory: packages/packagename
+```

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: tag to register the published package with
     required: false
     default: "latest"
+  working-directory:
+    description: Path of the package.json
+    required: false
+    default: "."
 
 runs:
   using: composite
@@ -20,5 +24,6 @@ runs:
 
     - name: Publish npm
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         npm publish --tag ${{ inputs.tag }}


### PR DESCRIPTION
In order to allow publishing packages which are not in the root folder.
This is particularly needed for the library [https://github.com/lessonnine/languages-config.lib](https://github.com/lessonnine/languages-config.lib)

based on @juanibiapina's work in [publish-gem](https://github.com/babbel/publish-gem/pull/2)